### PR TITLE
Use FreeRTOS Software Timers for TimeEvent

### DIFF
--- a/examples/blinky-efm32/FreeRTOSConfig.h
+++ b/examples/blinky-efm32/FreeRTOSConfig.h
@@ -67,7 +67,7 @@
 #define configSUPPORT_STATIC_ALLOCATION  1
 
 /* Timer related defines. */
-#define configUSE_TIMERS                0
+#define configUSE_TIMERS                1
 #define configTIMER_TASK_PRIORITY       2
 #define configTIMER_QUEUE_LENGTH        20
 #define configTIMER_TASK_STACK_DEPTH    ( configMINIMAL_STACK_SIZE * 2 )

--- a/examples/blinky-efm32/bsp.c
+++ b/examples/blinky-efm32/bsp.c
@@ -31,6 +31,17 @@
 #define PB0_PIN    6
 #define PB1_PIN    7
 
+/* Function Prototype ======================================================*/
+void vApplicationTickHook(void);
+void vApplicationIdleHook(void);
+void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName);
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
+                                   StackType_t **ppxIdleTaskStackBuffer,
+                                   uint32_t *pulIdleTaskStackSize);
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
+                                    StackType_t **ppxTimerTaskStackBuffer,
+                                    uint32_t *pulTimerTaskStackSize);
+
 /* Hooks ===================================================================*/
 /* Application hooks used in this project ==================================*/
 /* NOTE: only the "FromISR" API variants are allowed in vApplicationTickHook*/
@@ -44,9 +55,6 @@ void vApplicationTickHook(void) {
     } buttons = { 0U, 0U };
     uint32_t current;
     uint32_t tmp;
-
-    /* perform clock tick processing */
-    TimeEvent_tickFromISR(&xHigherPriorityTaskWoken);
 
     /* Perform the debouncing of buttons. The algorithm for debouncing
     * adapted from the book "Embedded Systems Dictionary" by Jack Ganssle
@@ -95,33 +103,62 @@ void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
 }
 /*..........................................................................*/
 /* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must
-* provide an implementation of vApplicationGetIdleTaskMemory() to provide
-* the memory that is used by the Idle task.
-*/
+ * provide an implementation of vApplicationGetIdleTaskMemory() to provide
+ * the memory that is used by the Idle task.
+ */
 void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
                                    StackType_t **ppxIdleTaskStackBuffer,
-                                   uint32_t *pulIdleTaskStackSize )
+                                   uint32_t *pulIdleTaskStackSize)
 {
     /* If the buffers to be provided to the Idle task are declared inside
-    * this function then they must be declared static - otherwise they will
-    * be allocated on the stack and so not exists after this function exits.
-    */
+     * this function then they must be declared static - otherwise they will
+     * be allocated on the stack and so not exists after this function exits.
+     */
     static StaticTask_t xIdleTaskTCB;
-    static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE];
+    static StackType_t  uxIdleTaskStack[configMINIMAL_STACK_SIZE];
 
     /* Pass out a pointer to the StaticTask_t structure in which the
-    * Idle task's state will be stored.
-    */
+     * Idle task's state will be stored.
+     */
     *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
 
     /* Pass out the array that will be used as the Idle task's stack. */
-    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+    *ppxIdleTaskStackBuffer = &uxIdleTaskStack[0];
 
     /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-    * Note that, as the array is necessarily of type StackType_t,
-    * configMINIMAL_STACK_SIZE is specified in words, not bytes.
-    */
-    *pulIdleTaskStackSize = sizeof(uxIdleTaskStack)/sizeof(uxIdleTaskStack[0]);
+     * Note that, as the array is necessarily of type StackType_t,
+     * configMINIMAL_STACK_SIZE is specified in words, not bytes.
+     */
+    *pulIdleTaskStackSize = sizeof(uxIdleTaskStack) / sizeof(uxIdleTaskStack[0]);
+}
+
+/* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must
+ * provide an implementation of vApplicationGetTimerTaskMemory() to provide
+ * the memory that is used by the Timer task.
+ */
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
+                                    StackType_t **ppxTimerTaskStackBuffer,
+                                    uint32_t *pulTimerTaskStackSize) {
+    /* If the buffers to be provided to the Timer task are declared inside
+     * this function then they must be declared static - otherwise they will
+     * be allocated on the stack and so not exists after this function exits.
+     */
+    static StaticTask_t xTimerTask_TCB;
+    static StackType_t  uxTimerTaskStack[configTIMER_TASK_STACK_DEPTH];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the
+     * Timer task's state will be stored.
+     */
+    *ppxTimerTaskTCBBuffer   = &xTimerTask_TCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = &uxTimerTaskStack[0];
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+     * Note that, as the array is necessarily of type StackType_t,
+     * configTIMER_TASK_STACK_DEPTH is specified in words, not bytes.
+     */
+    *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
 }
 
 /* BSP functions ===========================================================*/

--- a/examples/blinky-efm32/main.c
+++ b/examples/blinky-efm32/main.c
@@ -24,6 +24,9 @@ typedef struct {
     bool isLedOn;
 } BlinkyButton;
 
+/* Function Prototype ============================================================*/
+void BlinkyButton_ctor(BlinkyButton * const me);
+
 static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e) {
     switch (e->sig) {
         case INIT_SIG: /* intentionally fall through... */
@@ -31,12 +34,12 @@ static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e
             if (!me->isLedOn) { /* LED not on */
                 BSP_led0_on();
                 me->isLedOn = true;
-                TimeEvent_arm(&me->te, (200 / portTICK_RATE_MS), 0U);
+                TimeEvent_arm(&me->te, (200 / portTICK_RATE_MS));
             }
             else {  /* LED is on */
                 BSP_led0_off();
                 me->isLedOn = false;
-                TimeEvent_arm(&me->te, (800 / portTICK_RATE_MS), 0U);
+                TimeEvent_arm(&me->te, (800 / portTICK_RATE_MS));
             }
             break;
         }
@@ -55,6 +58,7 @@ static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e
 }
 void BlinkyButton_ctor(BlinkyButton * const me) {
     Active_ctor(&me->super, (DispatchHandler)&BlinkyButton_dispatch);
+    me->te.type = TYPE_ONE_SHOT;
     TimeEvent_ctor(&me->te, TIMEOUT_SIG, &me->super);
     me->isLedOn = false;
 }

--- a/examples/blinky-tm4c/FreeRTOSConfig.h
+++ b/examples/blinky-tm4c/FreeRTOSConfig.h
@@ -67,7 +67,7 @@
 #define configSUPPORT_STATIC_ALLOCATION  1
 
 /* Timer related defines. */
-#define configUSE_TIMERS                0
+#define configUSE_TIMERS                1
 #define configTIMER_TASK_PRIORITY       2
 #define configTIMER_QUEUE_LENGTH        20
 #define configTIMER_TASK_STACK_DEPTH    ( configMINIMAL_STACK_SIZE * 2 )

--- a/examples/blinky-tm4c/bsp.c
+++ b/examples/blinky-tm4c/bsp.c
@@ -25,6 +25,17 @@
 /* on-board switch */
 #define BTN_SW1   (1U << 4)
 
+/* Function Prototype ======================================================*/
+void vApplicationTickHook(void);
+void vApplicationIdleHook(void);
+void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName);
+void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
+                                   StackType_t **ppxIdleTaskStackBuffer,
+                                   uint32_t *pulIdleTaskStackSize);
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
+                                    StackType_t **ppxTimerTaskStackBuffer,
+                                    uint32_t *pulTimerTaskStackSize);
+
 /* Hooks ===================================================================*/
 /* Application hooks used in this project ==================================*/
 /* NOTE: only the "FromISR" API variants are allowed in vApplicationTickHook*/
@@ -38,9 +49,6 @@ void vApplicationTickHook(void) {
     } buttons = { 0U, 0U };
     uint32_t current;
     uint32_t tmp;
-
-    /* perform clock tick processing */
-    TimeEvent_tickFromISR(&xHigherPriorityTaskWoken);
 
     /* Perform the debouncing of buttons. The algorithm for debouncing
     * adapted from the book "Embedded Systems Dictionary" by Jack Ganssle
@@ -89,33 +97,62 @@ void vApplicationStackOverflowHook(TaskHandle_t xTask, char *pcTaskName) {
 }
 /*..........................................................................*/
 /* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must
-* provide an implementation of vApplicationGetIdleTaskMemory() to provide
-* the memory that is used by the Idle task.
-*/
+ * provide an implementation of vApplicationGetIdleTaskMemory() to provide
+ * the memory that is used by the Idle task.
+ */
 void vApplicationGetIdleTaskMemory(StaticTask_t **ppxIdleTaskTCBBuffer,
                                    StackType_t **ppxIdleTaskStackBuffer,
-                                   uint32_t *pulIdleTaskStackSize )
+                                   uint32_t *pulIdleTaskStackSize)
 {
     /* If the buffers to be provided to the Idle task are declared inside
-    * this function then they must be declared static - otherwise they will
-    * be allocated on the stack and so not exists after this function exits.
-    */
+     * this function then they must be declared static - otherwise they will
+     * be allocated on the stack and so not exists after this function exits.
+     */
     static StaticTask_t xIdleTaskTCB;
-    static StackType_t uxIdleTaskStack[configMINIMAL_STACK_SIZE];
+    static StackType_t  uxIdleTaskStack[configMINIMAL_STACK_SIZE];
 
     /* Pass out a pointer to the StaticTask_t structure in which the
-    * Idle task's state will be stored.
-    */
+     * Idle task's state will be stored.
+     */
     *ppxIdleTaskTCBBuffer = &xIdleTaskTCB;
 
     /* Pass out the array that will be used as the Idle task's stack. */
-    *ppxIdleTaskStackBuffer = uxIdleTaskStack;
+    *ppxIdleTaskStackBuffer = &uxIdleTaskStack[0];
 
     /* Pass out the size of the array pointed to by *ppxIdleTaskStackBuffer.
-    * Note that, as the array is necessarily of type StackType_t,
-    * configMINIMAL_STACK_SIZE is specified in words, not bytes.
-    */
-    *pulIdleTaskStackSize = sizeof(uxIdleTaskStack)/sizeof(uxIdleTaskStack[0]);
+     * Note that, as the array is necessarily of type StackType_t,
+     * configMINIMAL_STACK_SIZE is specified in words, not bytes.
+     */
+    *pulIdleTaskStackSize = sizeof(uxIdleTaskStack) / sizeof(uxIdleTaskStack[0]);
+}
+
+/* configSUPPORT_STATIC_ALLOCATION is set to 1, so the application must
+ * provide an implementation of vApplicationGetTimerTaskMemory() to provide
+ * the memory that is used by the Timer task.
+ */
+void vApplicationGetTimerTaskMemory(StaticTask_t **ppxTimerTaskTCBBuffer,
+                                    StackType_t **ppxTimerTaskStackBuffer,
+                                    uint32_t *pulTimerTaskStackSize) {
+    /* If the buffers to be provided to the Timer task are declared inside
+     * this function then they must be declared static - otherwise they will
+     * be allocated on the stack and so not exists after this function exits.
+     */
+    static StaticTask_t xTimerTask_TCB;
+    static StackType_t  uxTimerTaskStack[configTIMER_TASK_STACK_DEPTH];
+
+    /* Pass out a pointer to the StaticTask_t structure in which the
+     * Timer task's state will be stored.
+     */
+    *ppxTimerTaskTCBBuffer   = &xTimerTask_TCB;
+
+    /* Pass out the array that will be used as the Timer task's stack. */
+    *ppxTimerTaskStackBuffer = &uxTimerTaskStack[0];
+
+    /* Pass out the size of the array pointed to by *ppxTimerTaskStackBuffer.
+     * Note that, as the array is necessarily of type StackType_t,
+     * configTIMER_TASK_STACK_DEPTH is specified in words, not bytes.
+     */
+    *pulTimerTaskStackSize   = (uint32_t)configTIMER_TASK_STACK_DEPTH;
 }
 
 /* BSP functions ===========================================================*/

--- a/examples/blinky-tm4c/bsp.h
+++ b/examples/blinky-tm4c/bsp.h
@@ -1,6 +1,6 @@
 /*****************************************************************************
 * Lab Project: BlinkyButton/Button with Active Objects and FreeRTOS
-* Board: EMF32-SLSTK3401A
+* Board: EK-TM4C123GXL
 *
 *                    Q u a n t u m  L e a P s
 *                    ------------------------

--- a/examples/blinky-tm4c/main.c
+++ b/examples/blinky-tm4c/main.c
@@ -1,6 +1,6 @@
 /*****************************************************************************
 * Lab Project: BlinkyButton/Button with RTOS (FreeRTOS) and blocking
-* Board: EMF32-SLSTK3401A
+* Board: EK-TM4C123GXL
 *
 *                    Q u a n t u m  L e a P s
 *                    ------------------------
@@ -24,6 +24,9 @@ typedef struct {
     bool isLedOn;
 } BlinkyButton;
 
+/* Function Prototype ============================================================*/
+void BlinkyButton_ctor(BlinkyButton * const me);
+
 static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e) {
     switch (e->sig) {
         case INIT_SIG: /* intentionally fall through... */
@@ -31,12 +34,12 @@ static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e
             if (!me->isLedOn) { /* LED not on */
                 BSP_led0_on();
                 me->isLedOn = true;
-                TimeEvent_arm(&me->te, (200 / portTICK_RATE_MS), 0U);
+                TimeEvent_arm(&me->te, (200 / portTICK_RATE_MS));
             }
             else {  /* LED is on */
                 BSP_led0_off();
                 me->isLedOn = false;
-                TimeEvent_arm(&me->te, (800 / portTICK_RATE_MS), 0U);
+                TimeEvent_arm(&me->te, (800 / portTICK_RATE_MS));
             }
             break;
         }
@@ -55,6 +58,7 @@ static void BlinkyButton_dispatch(BlinkyButton * const me, Event const * const e
 }
 void BlinkyButton_ctor(BlinkyButton * const me) {
     Active_ctor(&me->super, (DispatchHandler)&BlinkyButton_dispatch);
+    me->te.type = TYPE_ONE_SHOT;
     TimeEvent_ctor(&me->te, TIMEOUT_SIG, &me->super);
     me->isLedOn = false;
 }


### PR DESCRIPTION
Instead of using vApplicationTickHook and call TimeEvent_tickFromISR() as simple software timer.
FreeRTOS Software Timers will bring the possibility of configUSE_TICKLESS_IDLE feature and using FreeAct in Low Power application.
https://www.freertos.org/RTOS-software-timer.html
https://www.freertos.org/EFM32-Giant-Gecko-Pearl-Gecko-tickless-RTOS-demo.html